### PR TITLE
Suggestion: Not a typo, just a different way to do it

### DIFF
--- a/docs/pbs120.md
+++ b/docs/pbs120.md
@@ -348,7 +348,16 @@ You could use your favourite plain-text editor to remove this line, or, we can t
 temp=$(head -2 .gitignore) && echo $temp > .gitignore
 ```
 
-If you're curious, this command saves the first two lines of our `.gitignore` into a shell variable named `$temp` and then echos that variable's value into a fresh `.gitignore` file.
+If you're curious, this command saves the first two lines of our `.gitignore` into a shell variable named `$temp` and then echoes that variable's value into a fresh `.gitignore` file.
+
+>> *(added to show notes after recording)*
+>>
+>> *There are at least two ways to do just about everything in Linux, if not more. Unsatisfied with my solution, a listener suggested that the following would accomplish the same as the above with possibly less confusing syntax.*
+> ```
+> head -n -1 .gitignore > .gitignore
+> ```
+>
+> This prints *all lines except* the last 1 line of our `.gitignore` file to `STDOUT` and then redirects it into a fresh `.gitignore` file. The `-` before the `1` means "print all except the last `N` lines of the file". If we had typed `head -n -2`, it would have cut off the last 2 lines of the file instead.
 
 If this file were new, it would now be ignored, but it's not new, it's tracked, so the file still exists in the repo!
 

--- a/docs/pbs120.md
+++ b/docs/pbs120.md
@@ -352,12 +352,12 @@ If you're curious, this command saves the first two lines of our `.gitignore` in
 
 >> *(added to show notes after recording)*
 >>
->> *There are at least two ways to do just about everything in Linux, if not more. Unsatisfied with my solution, a listener suggested that the following would accomplish the same as the above with possibly less confusing syntax.*
+>> *There are at least two ways to do just about everything in Linux, if not more. Unsatisfied with my solution, a listener suggested that the following would accomplish the same thing with possibly less confusing syntax. The version of `head` in MacOS doesn't have this option, which is why I didn't include it originally, but if you're using a modern Linux distribution, try:*
 > ```
 > head -n -1 .gitignore > .gitignore
 > ```
 >
-> This prints *all lines except* the last 1 line of our `.gitignore` file to `STDOUT` and then redirects it into a fresh `.gitignore` file. The `-` before the `1` means "print all except the last `N` lines of the file". If we had typed `head -n -2`, it would have cut off the last 2 lines of the file instead.
+> This prints *all lines except* the last (1) line of our `.gitignore` file to `STDOUT` and then redirects it into a fresh `.gitignore` file. The `-` before the `1` means "print all except the last `N` lines of the file". If we had typed `head -n -2`, it would have cut off the last 2 lines of the file instead.
 
 If this file were new, it would now be ignored, but it's not new, it's tracked, so the file still exists in the repo!
 


### PR DESCRIPTION
I added a small section showing how to cut the last N lines off a file using `head -n -N filename` where N is the number of lines to remove.

Since you talked in the actual show about the method you put in the notes, it doesn't seem to make sense to replace it completely, but you said something like "there isn't a command to cut the last line off of a file" but I think this is it.

Also, I forgot this commit also had a change of `echos` to `echoes`, so I lied, there is one typo. 