### PR TITLE
Fixed two typos in PBS 3

### DIFF
--- a/docs/pbs3.md
+++ b/docs/pbs3.md
@@ -77,7 +77,7 @@ The entire list should be contained within `<dl>` tags. Terms should be containe
 
 If multiple terms have the same definition, you can have a number of consecutive `<dt>` tags followed by a single `<dd>` tag.
 
-`<dl>` tags should only contain `<dt>` and `<dd>` tags, `<dt>` tags should only contain inline tags, and `<ds>` tags can contain any other tags, including block-level tags.
+`<dl>` tags should only contain `<dt>` and `<dd>` tags, `<dt>` tags should only contain inline tags, and `<dd>` tags can contain any other tags, including block-level tags.
 
 ```html
 <dl>

--- a/docs/pbs3.md
+++ b/docs/pbs3.md
@@ -195,7 +195,7 @@ Start by adding a folder called `pbs3` to the document root of your web server. 
   <p>- W. B. Yeats</p>
 </blockquote>
 
-<p>(notice the use of explicit line-breaks within a paragrpah)</p>
+<p>(notice the use of explicit line-breaks within a paragraph)</p>
 </body>
 </html>
 ```


### PR DESCRIPTION
Found two typos in PBS 3. I'm guessing the `<ds>` tag was supposed to be a `<dd>`...

PS.
Thank you for the tutorials, I'm loving TTT and PBS!