### PR TITLE
Fix typos in PBS 122

### DIFF
--- a/docs/pbs122.md
+++ b/docs/pbs122.md
@@ -168,7 +168,7 @@ As you can see, I'm using Zsh, but if I were using Bash the value would be `/bin
 
 If you're using Zsh you should export your environment variables in `~/.zshenv`, and if you're using Bash you should export them in `~/.bash_profile`. I'm going to use Zsh in the example below, but if you're using Bash, substitution `~/.bash_profile` for `~/.zshenv` in all the commands.
 
-Note that Chezmoi can only manage file that exist, so we need to be sure there is a `~/.zshenv` (or `~/.bash_profile`) before we can add it, but there is a possibility you already have a copy of this file with important settings in it, so, we need to ensure it exists in a non-destructive way. The simplest approach is to append a comment to the end of the file with the `echo` command, e.g.:
+Note that Chezmoi can only manage files that exist, so we need to be sure there is a `~/.zshenv` (or `~/.bash_profile`) before we can add it, but there is a possibility you already have a copy of this file with important settings in it, so, we need to ensure it exists in a non-destructive way. The simplest approach is to append a comment to the end of the file with the `echo` command, e.g.:
 
 ```
 echo '#boogers' >> ~/.zshenv
@@ -247,7 +247,7 @@ I started this section by noting that if you didn't want to get under the hood t
 
 ### Committing the Changes
 
-At this point we've added three files to Chezmoi, edit one, but committed nothing to Git.
+At this point we've added three files to Chezmoi, edited one, but committed nothing to Git.
 
 At this stage we have a standard Git repo with three new files and no commits. Let's use plain Git to get our changes committed in an orderly fashion:
 


### PR DESCRIPTION
Fixed two typos in PBS 122.

PS.
Don't know why git diff is showing the last paragraph is changed. It looks unchanged to me, and any possible change was unintentional. Could it be a newline thing?

PPS.
I hope I'm doing this right. I'm not sure why me merging the master branch into my fix-typos branch shows up as a separate commit in the pull request - this should already exist in the master branch, no?