### PR TITLE
PBS139: Minor typo fix in show notes

### DIFF
--- a/docs/pbs139.md
+++ b/docs/pbs139.md
@@ -64,7 +64,7 @@ The only change in the file is the addition of a new rule in the `rules` array:
 
 This tells Webpack that any file ending in `.mustache` should be available for import into JavaScript as a *source asset*, i.e. the contents of the file should be read as a string.
 
-With this config in place any Mustache template can be imported into and JavaScript file with an ES6 import statement of the form:
+With this config in place any Mustache template can be imported into a JavaScript file with an ES6 import statement of the form:
 
 ```js
 const myTemplateString = import('./templates/myTemplate.type.moustache');


### PR DESCRIPTION
Replace 'and' with 'a'