### PR TITLE
fix: PBS21 correct typo

### DIFF
--- a/docs/pbs21.md
+++ b/docs/pbs21.md
@@ -274,9 +274,9 @@ We know that we can hide an HTML element on a page by setting its CSS `display` 
 To show the animations in all their glory, let’s hide, then show, and finally toggle the Server Side section with a One second animation:
 
 ```javascript
-var aniTime = 1000;
+var anyTime = 1000;
 var $serverSec = $('section#sec_server');
-$serverSec.hide(aniTime);
+$serverSec.hide(anyTime);
 $serverSec.show(anyTime);
 $serverSec.toggle(anyTime);
 ```


### PR DESCRIPTION
In the section "jQuery and CSS", in the 'show/hide/toggle' example the variable is declared as "aniTime" and then used as both "aniTime" and "anyTime". "ani" was changed to "any" so that it is "anyTime" throughout.