### PR TITLE
Fix: PBS127 fix typo

### DIFF
--- a/docs/pbs127.md
+++ b/docs/pbs127.md
@@ -60,7 +60,7 @@ For example, to import the latest version of the MomentJS module into a NodeJS p
 
 Almost all the 3rd-party code we've used so far in this series has been used as traditional dependencies, but there are two exceptions — the testing framework [QUnit](https://qunitjs.com/) is a dev dependency, as is the document generator [JSDoc](https://jsdoc.app/). QUnit helps us create code, but the code we create runs just fine without it. Our code does not depend on QUnit, but our development process does.
 
-Our first milestone is to ship a JavaScript version of the exiting [Crypt::HSXKPasswd](https://metacpan.org/pod/Crypt::HSXKPasswd) Perl module. The first thing we'll be using NPM for is to manage our dev dependencies, specifically, to provide us with:
+Our first milestone is to ship a JavaScript version of the existing [Crypt::HSXKPasswd](https://metacpan.org/pod/Crypt::HSXKPasswd) Perl module. The first thing we'll be using NPM for is to manage our dev dependencies, specifically, to provide us with:
 
 1. A code linter [ESLint](https://eslint.org/)
 2. A testing framework (TBD)

--- a/docs/pbs130.md
+++ b/docs/pbs130.md
@@ -109,7 +109,7 @@ Oh well — at least I have lots of experience with JSDoc and it's various foibl
 
 ### JSDoc's Key Features
 
-Now that I've made it clear that I don't think JSDoc is perfect, let me explain why I think it's an extremely powerful tool that will serve use well.
+Now that I've made it clear that I don't think JSDoc is perfect, let me explain why I think it's an extremely powerful tool that will serve us well.
 
 1. JSDoc uses  variant of the [JavaDoc](https://en.wikipedia.org/wiki/Javadoc) syntax that's becomes a defacto pseudo-standard generally referred to as *doc comments*, and is now supported across multiple languages, including PHP (with [PHPDocumentor AKA PHPDoc](https://www.phpdoc.org)). 
 2. *Doc comments* are specially formatted code comments, and they're placed directly before the thing they're documenting in the source code.  Your documentation is right next to your code, so you can update them in unison with ease.

--- a/docs/pbs130.md
+++ b/docs/pbs130.md
@@ -4,7 +4,7 @@ It's all well and good to say that you write such good code that it's *effective
 
 Way back in the early days of this series, when we were just dipping our toes into the programming water I shared one of my favourite programming clichés — *comments are like coffee, good comments are great, but any comments are better than none* 🙂
 
-That may not even be really true for comments, but it's definitely not true for technical documentation. What's worse than no docs? Out of date or inaccurate docs! Codes doesn't become well documented organically — it requires a consciously designed process, and the discipline to stick to it. There simply is no proverbial free lunch to be had here — sorry!
+That may not even be really true for comments, but it's definitely not true for technical documentation. What's worse than no docs? Out of date or inaccurate docs! Code doesn't become well documented organically — it requires a consciously designed process, and the discipline to stick to it. There simply is no proverbial free lunch to be had here — sorry!
 
 However, like with lunches, good tools can really help. Just like It's a heck of a lot easier to cook to a well thought out plan in a well equipped kitchen that's been organised such that you have all the tools and ingredients to hand just as you need them, it's a heck of a lot easier to write useful documentation with the support of a good toolkit! That's where documentation generators come in.
 
@@ -97,7 +97,7 @@ He's referring to the very destructive pressure often put on politicians not to 
 ### Longer is not a Synonym for Better!
 On a related note — better doc does not always mean longer docs! Sometimes more really is more, but particularly as a function, class, or entire API matures, shorter, clearer descriptions are often much better than longer ones. To me, it's a sign that I'm on the right path when my descriptions become simpler instead of more complex.
 
-To abuse an old cliché goes — *I'm sorry I wrote you such long docs, I'm still working on shortening them* 😉
+To abuse a Mark Twain witticism — *I'm sorry I wrote you such long docs, I'm still working on shortening them* 😉
 
 ## Our Toolkit (JSDoc + ESLint)
 

--- a/docs/pbs132.md
+++ b/docs/pbs132.md
@@ -2,7 +2,7 @@
 
 We started our short journey into the world of documentation in instalment 130 by exploring the more philosophical side of documentation — why it's a good idea in general, why we need it for our project, who our audiences are, and what documentation we need. I also explained why I think JSDoc is a good fit for us, and set the big-picture scene. We will use JSDoc comments to embed our API documentation into our source code, we'll add some additional static content, and there will be two versions of our documentation, one for developers using the API, and one for contributors helping to write the API itself.
 
-With that foundation laid, we spend the previous instalment learning about those JSDoc comments we'll be embedding in our source code. Now, in this instalment, we'll look at the practicalities of managing our documentation within the project, how we can add a lot of very useful automation, and we'll look at how we can customise the look of the generated documentation with a JSDoc theme.
+With that foundation laid, we spent the previous instalment learning about those JSDoc comments we'll be embedding in our source code. Now, in this instalment, we'll look at the practicalities of managing our documentation within the project, how we can add a lot of very useful automation, and we'll look at how we can customise the look of the generated documentation with a JSDoc theme.
 
 ## Matching Podcast Episode
 
@@ -72,7 +72,7 @@ You might imagine we should set the destination folder in the config file too. T
 1. There is no one output dir for us, we will be generating two sets of documentation for our two audiences after all.
 2. As part of our automation of the process we'll need to empty this folder, so to avoid having to change the value in two places, we should specify it in the automation only.
 
-However there are two more option we should set while we're editing this section of the config. Firstly, it's good practice to be specific about character encodings, so let's use the `--encoding` flag to specify UTF8. Secondly, by default JSDoc quietly swallows a lot of errors and warnings which means we can end up with doc comments being silently dropped from the output. To avoid that we need to set the `--pedantic` flag:
+However there are two more options we should set while we're editing this section of the config. Firstly, it's good practice to be specific about character encodings, so let's use the `--encoding` flag to specify UTF8. Secondly, by default JSDoc quietly swallows a lot of errors and warnings which means we can end up with doc comments being silently dropped from the output. To avoid that we need to set the `--pedantic` flag:
 
 ```json
 {


### PR DESCRIPTION
In the "NPM for Dependency Management" section, 6th paragraph, 1st sentence: "... a JavaScript version of the exiting ...", "exiting" s/b "existing".