### PR TITLE
Fix: PBS128 fix typos

### DIFF
--- a/docs/pbs128.md
+++ b/docs/pbs128.md
@@ -141,7 +141,7 @@ The most consequential difference between ES 6 and Common JS is how modules get 
 
 This gives a very different execution order, and it has the advantage of allowing the code to generate the identifiers for the modules to load later in the process. This is so-called *dynamic loading*, and it's not possible in the original ES 6 module specification (it's coming, but not yet fully supported).
 
-CommonJS's approach is easier to understand, and it allows dynamic loading, so what tradeoff did they have to make to allow that? CommonJS can't deal with loops in the dependency three. If module A imports modules B, and module B modules C, then module C module A or B, then you have a loop, and CommonJS fails.
+CommonJS's approach is easier to understand, and it allows dynamic loading, so what tradeoff did they have to make to allow that? CommonJS can't deal with loops in the dependency tree. If module A imports module B, and module B module C, then module C module A or B, then you have a loop, and CommonJS fails.
 
 With it's three-step process and depth-first post-order execution approach, ES 6 Modules can handle dependency loops just fine.
 


### PR DESCRIPTION
In the section, "How ES 6 Contrasts with CommonJS", paragraph 3, sentence 2: "CommonJS can’t deal with loops in the dependency three.", "three" s/b "tree".

Sentence 4: "If module A imports modules B, and module B modules C ...", in both cases "modules" s/b "module".