### PR TITLE
Fix: Correct sentence.

### DIFF
--- a/docs/pbs136.md
+++ b/docs/pbs136.md
@@ -272,7 +272,7 @@ with valid data
 
 Note that each inner array contains three elements, a description, an array to use as input to the join function, and the expected output as a string.
 
-Each array defines arguments that will be passed to the arrow function that defines the tests, so we name the values when we define that arrow function, in this case, we name the first argument `desc`, the second `input`, and the third `output`. We can then use those names when defining our test.
+Each array defines arguments that will be passed to the arrow function that defines the tests, so we name the values when we define that arrow function, in this case, we name the first argument `desc`, the second `input`, and the third `result`. We can then use those names when defining our test.
 
 Note that adding an additional test is as simple as adding another inner array with the needed data.
 


### PR DESCRIPTION
In the section "Repeatable Tests with describe.each()()", third paragraph from the bottom, "... and the third output." "output" should be "result".