### PR TITLE
Fix: PBS29 correct typo

### DIFF
--- a/docs/pbs29.md
+++ b/docs/pbs29.md
@@ -55,7 +55,7 @@ Below is my solution to the challenge from [the previous instalment](https://pbs
 // init name space - commented out in playground
 var pbs = pbs ? pbs : {};
 
-// define all prototypes within an anonymous self executing fuction
+// define all prototypes within an anonymous self executing function
 (function(pbs, undefined){
   //
   // ==== Define Needed Helper Functions ===

--- a/docs/pbs30.md
+++ b/docs/pbs30.md
@@ -26,7 +26,7 @@ You can also <a href="https://media.blubrry.com/nosillacast/traffic.libsyn.com/n
 // init name space
 var pbs = pbs ? pbs : {};
 
-// define all prototypes within an anonymous self executing fuction
+// define all prototypes within an anonymous self executing function
 (function(pbs, undefined){
 	//
 	// ==== Define Needed Helper Functions ===


### PR DESCRIPTION
In the "Solution to PBS 28 Challenge" section, second comment in the code, " ... self executing fuction", "fuction" s/b "function". (This is also true in the download file for the show.)