### PR TITLE
typo correction

### DIFF
--- a/docs/pbs156.md
+++ b/docs/pbs156.md
@@ -46,7 +46,7 @@ This basic syntax works great when the keys are free from special characters, bu
 
 ```bash
 jq '.dependencies."is-it-check"' this-ti.me-package.json
-jq '.dependencies."@fontawesome/fontawesome-free"' this-ti.me-package.json
+jq '.dependencies."@fortawesome/fontawesome-free"' this-ti.me-package.json
 ```
 
 ## Descending into Arrays


### PR DESCRIPTION
example was  jq '.dependencies."@fortawesome/fontawesome-free"' this-ti.me-package.json

file contains:jq '.dependencies."@fortawesome/fontawesome-free"' this-ti.me-package.json