### PR TITLE
Fix: update freeipapi URL with new hostname

### DIFF
--- a/docs/_pbs/pbs155.md
+++ b/docs/_pbs/pbs155.md
@@ -128,10 +128,10 @@ Since we're going to be focusing on three common uses for JQ, let's' start with 
 
 ### Example 1 — Pretty-printing JSON from a Web Service
 
-The very useful site [freeipapi.com/](https://freeipapi.com/) offers a web service API that returns information about your IP address in JSON format from the URL [https://freeipapi.com/api/json](https://freeipapi.com/api/json). We can call this API from the terminal using the `curl` command like so:
+The very useful site [freeipapi.com/](https://freeipapi.com/) offers a web service API that returns information about your IP address in JSON format from the URL [https://free.freeipapi.com/api/json](https://free.freeipapi.com/api/json). We can call this API from the terminal using the `curl` command like so:
 
 ```bash
-curl https://freeipapi.com/api/json
+curl https://free.freeipapi.com/api/json
 ```
 
 When you do you'll see it returns its JSON as a long single-line string, e.g. this is what's returned when I run the command on my web server:
@@ -143,7 +143,7 @@ When you do you'll see it returns its JSON as a long single-line string, e.g. th
 This is not very human-friendly, so to see the information nicely formatted we can pipe it through `jq` without any jq filter with the command:
 
 ```bash
-curl -s https://freeipapi.com/api/json | jq
+curl -s https://free.freeipapi.com/api/json | jq
 ```
 
 What we get now is nicely formatted and syntax-highlighted JSON:


### PR DESCRIPTION
Hi Bart & Allison

I had occasion to go back to [PBS 155](https://pbs.bartificer.net/pbs155) and tried the `jq` example and it didn't work.

I figured out they seem to have updated the URL for their APIs.    So this change fixes up the example to work again.

thanks,  ---Ian

reference: https://freeipapi.com/docs/api-reference/api-introduction